### PR TITLE
Setup release-notes action

### DIFF
--- a/.github/workflows/test-setup-release-notes.yaml
+++ b/.github/workflows/test-setup-release-notes.yaml
@@ -1,0 +1,89 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: test-release-notes-action
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relnotes: ${{ steps.filter.outputs.relnotes }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: filter
+        with:
+          filters: |
+            relnotes:
+              - 'setup-release-notes/**'
+              - '.github/workflows/test-setup-release-notes.yaml'
+
+  test_relnotes_action:
+    needs: changes
+    if: ${{ needs.changes.outputs.relnotes == 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    permissions: {}
+    name: Install release-notes and test presence in path
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Install release notes
+        uses: ./setup-release-notes
+      - name: Check install!
+        run: release-notes --help
+      - name: Check root directory
+        run: |
+          if [[ $(git diff --stat) != '' ]]; then
+            echo 'should be clean'
+            exit 1
+          else
+            exit 0
+          fi
+        shell: bash
+
+  test_relnotes_with_go_install:
+    permissions: {}
+    needs: changes
+    if: ${{ needs.changes.outputs.relnotes == 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        go_version:
+          - '1.20'
+          - '1.21'
+    name: Try to install release-notes with go ${{ matrix.go_version }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ matrix.go_version }}
+          check-latest: true
+      - name: Install release-notes
+        uses: ./setup-release-notes
+      - name: Check install!
+        run: release-notes --help
+
+  

--- a/publish-release/README.md
+++ b/publish-release/README.md
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Install publish-release
-        uses: puerco/release-actions/setup-publish-release@main
+        uses: kubernetes-sigs/release-actions/setup-publish-release@main
 
       - name: Publish Release
-        uses: puerco/release-actions/publish-release@main
+        uses: kubernetes-sigs/release-actions/publish-release@main
         with:
             assets: "kubernetes.png|starship.toml"
         env:

--- a/setup-publish-release/README.md
+++ b/setup-publish-release/README.md
@@ -11,7 +11,7 @@ This action clones the Kubernetes Release Engineering respository and builds
 Add the following entry to your Github workflow YAML file:
 
 ```yaml
-uses: puerco/release-actions/setup-publish-release@main
+uses: kubernetes-sigs/release-actions/setup-publish-release@main
 ```
 
 Example using a pinned version:
@@ -26,7 +26,7 @@ jobs:
     name: Install publish release
     steps:
       - name: Install publish-releas
-        uses: puerco/release-actions/setup-publish-release@e9a41ac... 
+        uses: kubernetes-sigs/release-actions/setup-publish-release@e9a41ac... 
       - name: Check install!
         run: publish-release --help
 ```
@@ -35,7 +35,7 @@ Example using the default version:
 
 ```yaml
 jobs:
-  test_bom_action:
+  test_pubrel_action:
     runs-on: ubuntu-latest
 
     permissions: {}
@@ -43,16 +43,7 @@ jobs:
     name: Install publish-release and test presence in path
     steps:
       - name: Install publish-release
-        uses: puerco/release-actions/setup-publish-release@main
+        uses: kubernetes-sigs/release-actions/setup-publish-release@main
       - name: Check install!
         run: publish-release --help
 ```
-
-### Optional Inputs
-
-The following optional inputs:
-
-| Input | Description |
-| --- | --- |
-
-(TBD)

--- a/setup-publish-release/action.yaml
+++ b/setup-publish-release/action.yaml
@@ -14,16 +14,10 @@
 
 name: setup-publish-release
 author: puerco
-description: 'Install publish-release fromKubernetes SIG Release in your path'
+description: 'Install publish-release from Kubernetes SIG Release in your path'
 branding:
   icon: 'package'
   color: 'blue'
-
-inputs:
-  install-dir:
-    description: 'Where to install the binary'
-    required: false
-    default: '$HOME/.publish-release'
 
 runs:
   using: "composite"

--- a/setup-release-notes/README.md
+++ b/setup-release-notes/README.md
@@ -1,0 +1,50 @@
+# setup-publish-release GitHub Action
+
+This action enables you to install
+[release-notes](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
+in your runner.
+
+## Usage
+
+This action clones the Kubernetes Release Engineering respository and builds
+`release-notes` from source, adding it to the runner path.
+
+Add the following entry to your Github workflow YAML file:
+
+```yaml
+uses: kubernetes-sigs/release-actions/setup-publish-release@main
+```
+
+Example using a pinned version:
+
+```yaml
+jobs:
+  test_relnotes_action:
+    runs-on: ubuntu-latest
+
+    permissions: {}
+
+    name: Install release-notes
+    steps:
+      - name: Install release-notes
+        uses: kubernetes-sigs/release-actions/setup-release-notes@e9a41ac... 
+      - name: Check install!
+        run: release-notes --help
+```
+
+Example using the default version:
+
+```yaml
+jobs:
+  test_bom_action:
+    runs-on: ubuntu-latest
+
+    permissions: {}
+
+    name: Install release-notes and test presence in path
+    steps:
+      - name: Install release-notes
+        uses: kubernetes-sigs/release-actions/setup-publish-release@main
+      - name: Check install!
+        run: release-notes --help
+```

--- a/setup-release-notes/action.yaml
+++ b/setup-release-notes/action.yaml
@@ -1,0 +1,42 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: setup-publish-release
+author: puerco
+description: 'Install release-notes from Kubernetes SIG Release in your runner'
+branding:
+  icon: 'package'
+  color: 'blue'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.0.2
+
+    - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v3.3.0
+      with:
+        go-version: '1.21'
+        check-latest: true
+
+    - shell: bash
+      run: |
+        #!/usr/bin/env bash
+
+        temp_dir="$(mktemp -d)" && \
+          git clone --depth=1 -q https://github.com/kubernetes/release.git "${temp_dir}" && \
+          cd "${temp_dir}/"  && \
+          go build ./cmd/release-notes/ && \
+          mv release-notes /usr/local/bin/ && \
+          release-notes --help

--- a/setup-tejolote/README.md
+++ b/setup-tejolote/README.md
@@ -9,7 +9,7 @@ This action currently supports GitHub-provided Linux, macOS and Windows runners 
 Add the following entry to your Github workflow YAML file:
 
 ```yaml
-uses: puerco/release-actions/setup-tejolote@main
+uses: kubernetes-sigs/release-actions/setup-tejolote@main
 with:
   tejolote-release: '0.2.1' # optional
 ```
@@ -26,7 +26,7 @@ jobs:
     name: Install tejolote and test presence in path
     steps:
       - name: Install tejolote
-        uses: puerco/release-actions/setup-tejolote@main
+        uses: kubernetes-sigs/release-actions/setup-tejolote@main
         with:
           tejolote-release: '0.2.1' # optional
       - name: Check install!
@@ -45,7 +45,7 @@ jobs:
     name: Install tejolote and test presence in path
     steps:
       - name: Install tejolote
-        uses: puerco/release-actions/setup-tejolote@main
+        uses: kubernetes-sigs/release-actions/setup-tejolote@main
       - name: Check install!
         run: tejolote version
 ```

--- a/setup-zeitgeist/README.md
+++ b/setup-zeitgeist/README.md
@@ -10,7 +10,7 @@ This action currently supports GitHub-provided Linux, macOS and Windows runners 
 Add the following entry to your Github workflow YAML file:
 
 ```yaml
-uses: cpanato/setup-zeitgeist@main
+uses: kubernetes-sigs/setup-zeitgeist@main
 with:
   zeitgeist-release: '0.4.3' # optional
 ```
@@ -27,7 +27,7 @@ jobs:
     name: Install zeitgeist and test presence in path
     steps:
       - name: Install zeitgeist
-        uses: cpanato/setup-zeitgeist@main
+        uses: kubernetes-sigs/setup-zeitgeist@main
         with:
           zeitgeist-release: '0.4.3' # optional
       - name: Check install!
@@ -46,7 +46,7 @@ jobs:
     name: Install zeitgeist and test presence in path
     steps:
       - name: Install zeitgeist
-        uses: puerco/release-actions/setup-zeitgeist@main
+        uses: kubernetes-sigs/release-actions/setup-zeitgeist@main
       - name: Check install!
         run: zeitgeist version
 ```
@@ -70,7 +70,7 @@ jobs:
           go-version: 1.21
           check-latest: true
       - name: Install zeitgeist
-        uses: puerco/release-actions/setup-zeitgeist@main
+        uses: kubernetes-sigs/release-actions/setup-zeitgeist@main
         with:
           zeitgeist-release: main
       - name: Check install!


### PR DESCRIPTION
This PR adds a new action to setup `release-notes` in the runner. The ultimate goal is to be able to enforce and generate release notes using the tool from actions.

I've also pushed another commit updating the repository names in the documentation (removing carlos' and puerco's personal repos in favor of the kubernetes-sigs org).

/assign @cpanato 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>