### PR TITLE
Add setup krel github action

### DIFF
--- a/.github/workflows/test-setup-krel.yml
+++ b/.github/workflows/test-setup-krel.yml
@@ -1,0 +1,87 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: test-setup-krel
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      krel: ${{ steps.filter.outputs.krel }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            krel:
+              - 'setup-krel/**'
+              - '.github/workflows/test-setup-krel.yaml'
+
+  test_krel_action:
+    needs: changes
+    if: ${{ needs.changes.outputs.krel == 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest ]
+    permissions: { }
+    name: Install krel and verify installation
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install krel
+        id: install-krel
+        uses: ./setup-krel
+
+      - name: Verify krel installation
+        shell: bash
+        run: |
+          # Get the actual path from which
+          ACTUAL_PATH=$(which krel)
+          
+          # Get the reported path from the action output
+          REPORTED_PATH="${{ steps.install-krel.outputs.krel-path }}"
+          
+          echo "Actual path: $ACTUAL_PATH"
+          echo "Reported path: $REPORTED_PATH"
+          
+          # Verify output path is not empty
+          if [ -z "$REPORTED_PATH" ]; then
+            echo "krel-path output is empty"
+            exit 1
+          fi
+          
+          # Compare paths
+          if [ "$ACTUAL_PATH" != "$REPORTED_PATH" ]; then
+            echo "Path mismatch!"
+            echo "Action reported: $REPORTED_PATH"
+            echo "Actually installed at: $ACTUAL_PATH"
+            exit 1
+          fi
+          
+          # Validate the path exists and is executable
+          test -x "$REPORTED_PATH"
+          
+          # Check krel version
+          krel version

--- a/setup-krel/README.md
+++ b/setup-krel/README.md
@@ -1,0 +1,69 @@
+# setup-krel GitHub Action
+
+This action installs [krel](https://github.com/kubernetes/release/tree/master/cmd/krel) (Kubernetes Release Toolbox) in your GitHub Actions runner.
+
+## Usage
+
+This action installs the binary using `go install` command. Add the following entry to your Github workflow YAML file:
+
+```yaml
+- uses: kubernetes-sigs/release-actions/setup-krel@main
+```
+
+### Basic Example
+
+```yaml
+jobs:
+  test_setup_krel:
+    runs-on: ubuntu-latest
+    permissions: {}
+    name: Install krel
+    steps:
+      - name: Install krel
+        uses: kubernetes-sigs/release-actions/setup-krel@main
+      - name: Verify installation
+        run: krel version
+```
+
+### Example with Pinned Version (Recommended for Production)
+
+```yaml
+jobs:
+  test_setup_krel:
+    runs-on: ubuntu-latest
+    permissions: {}
+    name: Install krel
+    steps:
+      - name: Install krel
+        uses: kubernetes-sigs/release-actions/setup-krel@e9a41ac  # Replace with a specific commit SHA
+      - name: Verify installation
+        run: krel version
+```
+
+### Example Using the Installation Path Output
+
+```yaml
+jobs:
+  test_setup_krel:
+    runs-on: ubuntu-latest
+    permissions: {}
+    name: Install and use krel
+    steps:
+      - name: Install krel
+        id: krel-installation
+        uses: kubernetes-sigs/release-actions/setup-krel@main
+      
+      - name: Show krel path
+        run: echo "krel is installed at ${{ steps.krel-installation.outputs.krel-path }}"
+      
+      - name: Use krel from path
+        run: |
+          KREL_BIN="${{ steps.krel-installation.outputs.krel-path }}"
+          "$KREL_BIN" version
+```
+
+## Outputs
+
+| Output      | Description                            |
+|-------------|----------------------------------------|
+| `krel-path` | Full path to the installed krel binary |

--- a/setup-krel/action.yml
+++ b/setup-krel/action.yml
@@ -1,0 +1,62 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: setup-krel
+author: Vyom-Yadav
+description: 'Installs krel and includes it in your path'
+branding:
+  icon: 'package'
+  color: 'blue'
+
+outputs:
+  krel-path:
+    description: 'Path to the installed krel binary'
+    value: ${{ steps.install-krel.outputs.krel-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      with:
+        go-version: '1.23'
+        check-latest: true
+
+    - id: install-krel
+      shell: bash
+      run: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Installing krel..."
+        if ! go install k8s.io/release/cmd/krel@latest; then
+          echo "::error::Failed to install krel"
+          exit 1
+        fi
+
+        echo "Verifying krel installation..."
+        if ! command -v krel &> /dev/null; then
+          echo "::error::krel not found in PATH after installation"
+          exit 1
+        fi
+
+        echo "Testing krel..."
+        if ! krel --help &> /dev/null; then
+          echo "::error::krel --help failed, installation may be corrupted"
+          exit 1
+        fi
+
+        echo "krel installed successfully"
+        KREL_PATH=$(which krel)
+        echo "krel-path=$KREL_PATH" >> "$GITHUB_OUTPUT"
+        echo "Krel path: $KREL_PATH"


### PR DESCRIPTION
Adds a GitHub Action to setup krel.

This is required to setup a presubmit job for PRs like: https://github.com/kubernetes/sig-release/pull/2659. The current requirement is to add validation using:

```
$ krel release-notes validate --help
krel release-notes validate <path-to-release-notes>

The 'validate' subcommand of krel has been developed to:

1. Check release notes maps for valid yaml.

2. Check release notes maps for valid punctuation.

Usage:
  krel release-notes validate [flags]

Flags:
  -h, --help                           help for validate
      --path-to-release-notes string   The path to the release notes to validate. Can be a top level directory or a specific file.

```