### PR TITLE
Bump tejolote to v0.3.1

### DIFF
--- a/setup-tejolote/action.yml
+++ b/setup-tejolote/action.yml
@@ -23,7 +23,7 @@ inputs:
   tejolote-release:
     description: 'tejolote release version to be installed'
     required: false
-    default: '0.3.0'
+    default: '0.3.1'
   install-dir:
     description: 'Where to install the tejolote binary'
     required: false


### PR DESCRIPTION
Now that [tejolote v0.3.1 has been released](https://github.com/kubernetes-sigs/tejolote/releases/tag/v0.3.1), we bump the action to use it.

/cc @cpanato 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>