### PR TITLE
Add fallback for legacy cosign verification in setup-tejolote

### DIFF
--- a/.github/workflows/test-setup-tejolote.yml
+++ b/.github/workflows/test-setup-tejolote.yml
@@ -160,6 +160,29 @@ jobs:
           [[ -z $(git diff --stat) ]]
         shell: bash
 
+  test_tejolote_action_legacy:
+    if: ${{ needs.changes.outputs.tejolote == 'true' }}
+    needs:
+      - changes
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: read
+
+    name: Install legacy tejolote version with certificate/signature verification
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install tejolote
+        uses: ./setup-tejolote
+        with:
+          tejolote-release: '0.4.4'
+
+      - name: Check install!
+        run: tejolote version
+
   test_tejolote_action_wrong:
     if: ${{ needs.changes.outputs.tejolote == 'true' }}
     needs:

--- a/setup-tejolote/action.yml
+++ b/setup-tejolote/action.yml
@@ -134,12 +134,21 @@ runs:
         $SUDO curl -sL https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename} -o ${tejolote_executable_name}
 
         TEJOLOTE_BUNDLE_URL=https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename}.sigstore.json
-        $SUDO curl -sL "$TEJOLOTE_BUNDLE_URL" -o ${desired_tejolote_filename}.sigstore.json
+        TEJOLOTE_CERT=https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename}.pem
+        TEJOLOTE_SIG=https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename}.sig
 
         log_info "Using cosign to verify signature of desired tejolote version"
-        cosign verify-blob --bundle ${desired_tejolote_filename}.sigstore.json \
-          --certificate-identity "https://github.com/kubernetes-sigs/tejolote/.github/workflows/release.yml@refs/tags/v${{ inputs.tejolote-release }}" \
-          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${tejolote_executable_name}
+        if $SUDO curl -sfL "$TEJOLOTE_BUNDLE_URL" -o ${desired_tejolote_filename}.sigstore.json 2>/dev/null; then
+          log_info "Using bundle verification"
+          cosign verify-blob --bundle ${desired_tejolote_filename}.sigstore.json \
+            --certificate-identity "https://github.com/kubernetes-sigs/tejolote/.github/workflows/release.yml@refs/tags/v${{ inputs.tejolote-release }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${tejolote_executable_name}
+        else
+          log_info "Using legacy certificate/signature verification"
+          cosign verify-blob --certificate $TEJOLOTE_CERT --signature $TEJOLOTE_SIG \
+            --certificate-identity "https://github.com/kubernetes-sigs/tejolote/.github/workflows/release.yml@refs/tags/v${{ inputs.tejolote-release }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${tejolote_executable_name}
+        fi
         retVal=$?
         if [[ $retVal -eq 0 ]]; then
           $SUDO chmod +x ${tejolote_executable_name}


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes-sigs/release-actions/pull/153, which switched cosign verification to the new bundle format (`.sigstore.json`). That change breaks users pinning older tejolote versions that only ship `.pem`/`.sig` artifacts.

This adds a fallback: try the bundle format first, fall back to legacy certificate/signature verification if the bundle is not available.

/cc @cpanato @puerco