### PR TITLE
Update publish-release default version to v0.21.1

### DIFF
--- a/publish-release/action.yaml
+++ b/publish-release/action.yaml
@@ -23,7 +23,7 @@ inputs:
   publish-release-version:
     description: 'publish-release version to be installed'
     required: false
-    default: '0.21.0'
+    default: '0.21.1'
   install-only:
     description: "Only install publish-release binary"
     required: false


### PR DESCRIPTION
Bumps the default tool version installed by the publish-release action from v0.21.0 to v0.21.1.

Latest release: https://github.com/kubernetes/release/releases/tag/v0.21.1

```release-note
Update the default tool version installed by the publish-release action to v0.21.1
```
