### PR TITLE
Update setup-tejolote default version to v0.5.0

### DIFF
--- a/setup-tejolote/action.yml
+++ b/setup-tejolote/action.yml
@@ -23,7 +23,7 @@ inputs:
   tejolote-release:
     description: 'tejolote release version to be installed'
     required: false
-    default: '0.4.8'
+    default: '0.5.0'
   install-dir:
     description: 'Where to install the tejolote binary'
     required: false


### PR DESCRIPTION
Bumps the default tool version installed by the setup-tejolote action from v0.4.8 to v0.5.0.

Latest release: https://github.com/kubernetes-sigs/tejolote/releases/tag/v0.5.0

```release-note
Update the default tool version installed by the setup-tejolote action to v0.5.0
```
