### PR TITLE
Verify binaries with policy instead of cosign

### DIFF
--- a/publish-release/action.yaml
+++ b/publish-release/action.yaml
@@ -68,11 +68,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-      with:
-        install-dir: ${{ inputs.install-dir }}
-        use-sudo: ${{ inputs.use-sudo }}
-
     # if requested to install from go install
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       if: ${{ inputs.publish-release-version == 'main' }}
@@ -81,7 +76,8 @@ runs:
         check-latest: true
         cache: false
 
-    - shell: bash
+    - id: download
+      shell: bash
       run: |
         #!/usr/bin/env bash
         # publish-release install script
@@ -95,65 +91,36 @@ runs:
         fi
         set -e
 
-        mkdir -p ${{ inputs.install-dir }}
-
+        # main fast path: build from source with 'go install' and symlink the
+        # resulting binary into the install dir. No download or verification.
         if [[ ${{ inputs.publish-release-version }} == "main" ]]; then
           log_info "installing publish-release via 'go install' from its main version"
+          mkdir -p ${{ inputs.install-dir }}
           GOBIN=$(go env GOPATH)/bin
           go install k8s.io/release/cmd/publish-release@master
           ln -s $GOBIN/publish-release ${{ inputs.install-dir}}/publish-release
+          echo "mode=goinstall" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        trap "popd >/dev/null" EXIT
-
-        pushd ${{ inputs.install-dir }} > /dev/null
         publish_release_executable_name='publish-release'
         case ${{ runner.os }} in
           Linux)
             case ${{ runner.arch }} in
-              X64)
-                desired_publish_release_filename='publish-release-amd64-linux'
-                ;;
-
-              ARM64)
-                desired_publish_release_filename='publish-release-arm64-linux'
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_publish_release_filename='publish-release-amd64-linux' ;;
+              ARM64) desired_publish_release_filename='publish-release-arm64-linux' ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
           macOS)
             case ${{ runner.arch }} in
-              X64)
-                desired_publish_release_filename='publish-release-amd64-darwin'
-                ;;
-
-              ARM64)
-                desired_publish_release_filename='publish-release-arm64-darwin'
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_publish_release_filename='publish-release-amd64-darwin' ;;
+              ARM64) desired_publish_release_filename='publish-release-arm64-darwin' ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
-          *)
-            log_error "unsupported architecture $arch"
-            exit 1
-            ;;
+          *) log_error "unsupported architecture $arch"; exit 1 ;;
         esac
-
-        SUDO=
-        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
-          SUDO=sudo
-        fi
 
         semver='^([0-9]+\.){0,2}(\*|[0-9]+)$'
         if [[ ${{ inputs.publish-release-version }} =~ $semver ]]; then
@@ -163,25 +130,69 @@ runs:
           exit 1
         fi
 
-        # Download custom publish-release
-        log_info "Downloading platform-specific version '${{ inputs.publish-release-version }}' of publish-release...\n      https://github.com/kubernetes/release/releases/download/v${{ inputs.publish-release-version }}/${desired_publish_release_filename}"
-        $SUDO curl -sL https://github.com/kubernetes/release/releases/download/v${{ inputs.publish-release-version }}/${desired_publish_release_filename} -o ${publish_release_executable_name}
+        RELEASE_URL="https://github.com/kubernetes/release/releases/download/v${{ inputs.publish-release-version }}"
 
-        PUBLISH_RELEASE_CERT=https://github.com/kubernetes/release/releases/download/v${{ inputs.publish-release-version }}/${desired_publish_release_filename}.pem
-        PUBLISH_RELEASE_SIG=https://github.com/kubernetes/release/releases/download/v${{ inputs.publish-release-version }}/${desired_publish_release_filename}.sig
+        # Stage the binary and its signatures in a dedicated directory (relative
+        # to the workspace, which keeps the path portable across runners) so the
+        # AMPEL policy can be evaluated by collecting from it.
+        verify_dir="ampel-verify-publish-release"
+        rm -rf "${verify_dir}"
+        mkdir -p "${verify_dir}"
 
-        log_info "Using cosign to verify signature of desired publish-release version"
-        cosign verify-blob --certificate $PUBLISH_RELEASE_CERT --signature $PUBLISH_RELEASE_SIG \
-          --certificate-identity "https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/v${{ inputs.publish-release-version }}" \
-          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${publish_release_executable_name}
-        retVal=$?
-        if [[ $retVal -eq 0 ]]; then
-          $SUDO chmod +x ${publish_release_executable_name}
-          log_info "Installation complete!"
-        else
-          log_error "Unable to validate publish-release version: '${{ inputs.publish-release-version }}'"
-          exit 1
+        log_info "Downloading platform-specific version '${{ inputs.publish-release-version }}' of publish-release...\n      ${RELEASE_URL}/${desired_publish_release_filename}"
+        curl -sfL "${RELEASE_URL}/${desired_publish_release_filename}" -o "${verify_dir}/${desired_publish_release_filename}"
+
+        # Releases are signed either with a detached certificate + signature
+        # pair or with a sigstore bundle. Fetch whichever the release published;
+        # the others simply 404 and are removed.
+        for ext in .sig .pem .sigstore.json; do
+          if curl -sfL "${RELEASE_URL}/${desired_publish_release_filename}${ext}" -o "${verify_dir}/${desired_publish_release_filename}${ext}"; then
+            log_info "Fetched signature file ${desired_publish_release_filename}${ext}"
+          else
+            rm -f "${verify_dir}/${desired_publish_release_filename}${ext}"
+          fi
+          # Drop empty artifacts a server may hand back with a 200 response.
+          if [ -f "${verify_dir}/${desired_publish_release_filename}${ext}" ] && [ ! -s "${verify_dir}/${desired_publish_release_filename}${ext}" ]; then
+            rm -f "${verify_dir}/${desired_publish_release_filename}${ext}"
+          fi
+        done
+
+        {
+          echo "verify-dir=${verify_dir}"
+          echo "artifact=${verify_dir}/${desired_publish_release_filename}"
+          echo "executable=${publish_release_executable_name}"
+          echo "mode=download"
+        } >> "$GITHUB_OUTPUT"
+
+    # Verifies the downloaded binary carries a sigstore signature from the
+    # publish-release release workflow. The policy accepts both the legacy
+    # detached certificate + signature pair and the newer sigstore bundle.
+    - name: Verify publish-release signature
+      if: ${{ steps.download.outputs.mode == 'download' }}
+      uses: carabiner-dev/actions/ampel/verify@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+      with:
+        subject: ${{ steps.download.outputs.artifact }}
+        collector: fs:${{ steps.download.outputs.verify-dir }}
+        policy: git+https://github.com/carabiner-dev/policies#sigstore/sigstore-dual-signatures.json
+        signer: sigstore::https://token.actions.githubusercontent.com::https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/v${{ inputs.publish-release-version }}
+        attest: "false"
+
+    - name: Install publish-release
+      if: ${{ steps.download.outputs.mode == 'download' }}
+      shell: bash
+      run: |
+        set -e
+        SUDO=
+        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
+          SUDO=sudo
         fi
+        $SUDO mkdir -p "${{ inputs.install-dir }}"
+        $SUDO install -m 0755 "${ARTIFACT}" "${{ inputs.install-dir }}/${EXECUTABLE}"
+        rm -rf "${VERIFY_DIR}"
+      env:
+        ARTIFACT: ${{ steps.download.outputs.artifact }}
+        EXECUTABLE: ${{ steps.download.outputs.executable }}
+        VERIFY_DIR: ${{ steps.download.outputs.verify-dir }}
 
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       run: echo "${{ inputs.install-dir }}" >> $GITHUB_PATH

--- a/setup-bom/action.yml
+++ b/setup-bom/action.yml
@@ -35,11 +35,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-      with:
-        install-dir: ${{ inputs.install-dir }}
-        use-sudo: ${{ inputs.use-sudo }}
-    - shell: bash
+    - id: download
+      shell: bash
       run: |
         #!/usr/bin/env bash
         # bom install script
@@ -53,73 +50,34 @@ runs:
         fi
         set -e
 
-        mkdir -p ${{ inputs.install-dir }}
-
-        trap "popd >/dev/null" EXIT
-
-        pushd ${{ inputs.install-dir }} > /dev/null
         bom_executable_name='bom'
         case ${{ runner.os }} in
           Linux)
             case ${{ runner.arch }} in
-              X64)
-                desired_bom_filename='bom-amd64-linux'
-                ;;
-
-              ARM)
-                desired_bom_filename='bom-arm-linux'
-                ;;
-
-              ARM64)
-                desired_bom_filename='bom-arm64-linux'
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_bom_filename='bom-amd64-linux' ;;
+              ARM)   desired_bom_filename='bom-arm-linux' ;;
+              ARM64) desired_bom_filename='bom-arm64-linux' ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
           macOS)
             case ${{ runner.arch }} in
-              X64)
-                desired_bom_filename='bom-amd64-darwin'
-                ;;
-
-              ARM64)
-                desired_bom_filename='bom-arm64-darwin'
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_bom_filename='bom-amd64-darwin' ;;
+              ARM64) desired_bom_filename='bom-arm64-darwin' ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
           Windows)
             case ${{ runner.arch }} in
               X64)
                 desired_bom_filename='bom-amd64-windows.exe'
                 bom_executable_name=bom.exe
                 ;;
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-          *)
-            log_error "unsupported architecture $arch"
-            exit 1
-            ;;
+          *) log_error "unsupported architecture $arch"; exit 1 ;;
         esac
-
-        SUDO=
-        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
-          SUDO=sudo
-        fi
 
         semver='^([0-9]+\.){0,2}(\*|[0-9]+)$'
         if [[ ${{ inputs.bom-release }} =~ $semver ]]; then
@@ -129,25 +87,62 @@ runs:
           exit 1
         fi
 
-        # Download custom bom
-        log_info "Downloading platform-specific version '${{ inputs.bom-release }}' of bom...\n      https://github.com/kubernetes-sigs/bom/releases/download/v${{ inputs.bom-release }}/${desired_bom_filename}"
-        $SUDO curl -sL https://github.com/kubernetes-sigs/bom/releases/download/v${{ inputs.bom-release }}/${desired_bom_filename} -o ${bom_executable_name}
+        RELEASE_URL="https://github.com/kubernetes-sigs/bom/releases/download/v${{ inputs.bom-release }}"
 
-        BOM_CERT=https://github.com/kubernetes-sigs/bom/releases/download/v${{ inputs.bom-release }}/${desired_bom_filename}.pem
-        BOM_SIG=https://github.com/kubernetes-sigs/bom/releases/download/v${{ inputs.bom-release }}/${desired_bom_filename}.sig
+        # Stage the binary and its signatures in a dedicated directory (relative
+        # to the workspace, which keeps the path portable across runners) so the
+        # AMPEL policy can be evaluated by collecting from it.
+        verify_dir="ampel-verify-bom"
+        rm -rf "${verify_dir}"
+        mkdir -p "${verify_dir}"
 
-        log_info "Using cosign to verify signature of desired bom version"
-        cosign verify-blob --certificate $BOM_CERT --signature $BOM_SIG \
-          --certificate-identity "https://github.com/kubernetes-sigs/bom/.github/workflows/release.yml@refs/tags/v${{ inputs.bom-release }}" \
-          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${bom_executable_name}
-        retVal=$?
-        if [[ $retVal -eq 0 ]]; then
-          $SUDO chmod +x ${bom_executable_name}
-          log_info "Installation complete!"
-        else
-          log_error "Unable to validate bom version: '${{ inputs.bom-release }}'"
-          exit 1
+        log_info "Downloading platform-specific version '${{ inputs.bom-release }}' of bom...\n      ${RELEASE_URL}/${desired_bom_filename}"
+        curl -sfL "${RELEASE_URL}/${desired_bom_filename}" -o "${verify_dir}/${desired_bom_filename}"
+
+        # Releases are signed either with a detached certificate + signature
+        # pair or with a sigstore bundle. Fetch whichever the release published;
+        # the others simply 404 and are removed.
+        for ext in .sig .pem .sigstore.json; do
+          if curl -sfL "${RELEASE_URL}/${desired_bom_filename}${ext}" -o "${verify_dir}/${desired_bom_filename}${ext}"; then
+            log_info "Fetched signature file ${desired_bom_filename}${ext}"
+          else
+            rm -f "${verify_dir}/${desired_bom_filename}${ext}"
+          fi
+        done
+
+        {
+          echo "verify-dir=${verify_dir}"
+          echo "artifact=${verify_dir}/${desired_bom_filename}"
+          echo "executable=${bom_executable_name}"
+        } >> "$GITHUB_OUTPUT"
+
+    # Verifies the downloaded binary carries a sigstore signature from the
+    # bom release workflow. The policy accepts both the legacy detached
+    # certificate + signature pair and the newer sigstore bundle.
+    - name: Verify bom signature
+      uses: carabiner-dev/actions/ampel/verify@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+      with:
+        subject: ${{ steps.download.outputs.artifact }}
+        collector: fs:${{ steps.download.outputs.verify-dir }}
+        policy: git+https://github.com/carabiner-dev/policies#sigstore/sigstore-dual-signatures.json
+        signer: sigstore::https://token.actions.githubusercontent.com::https://github.com/kubernetes-sigs/bom/.github/workflows/release.yml@refs/tags/v${{ inputs.bom-release }}
+        attest: "false"
+
+    - name: Install bom
+      shell: bash
+      run: |
+        set -e
+        SUDO=
+        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
+          SUDO=sudo
         fi
+        $SUDO mkdir -p "${{ inputs.install-dir }}"
+        $SUDO install -m 0755 "${ARTIFACT}" "${{ inputs.install-dir }}/${EXECUTABLE}"
+        rm -rf "${VERIFY_DIR}"
+      env:
+        ARTIFACT: ${{ steps.download.outputs.artifact }}
+        EXECUTABLE: ${{ steps.download.outputs.executable }}
+        VERIFY_DIR: ${{ steps.download.outputs.verify-dir }}
 
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       run: echo "${{ inputs.install-dir }}" >> $GITHUB_PATH

--- a/setup-release-notes/action.yaml
+++ b/setup-release-notes/action.yaml
@@ -35,11 +35,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-      with:
-        install-dir: ${{ inputs.install-dir }}
-        use-sudo: ${{ inputs.use-sudo }}
-    - shell: bash
+    - id: download
+      shell: bash
       run: |
         #!/usr/bin/env bash
         # release notes install script
@@ -53,11 +50,6 @@ runs:
         fi
         set -e
 
-        mkdir -p ${{ inputs.install-dir }}
-
-        trap "popd >/dev/null" EXIT
-
-        pushd ${{ inputs.install-dir }} > /dev/null
         rn_executable_name='release-notes'
         case ${{ runner.os }} in
           Linux)
@@ -100,11 +92,6 @@ runs:
             ;;
         esac
 
-        SUDO=
-        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
-          SUDO=sudo
-        fi
-
         semver='^([0-9]+\.){0,2}(\*|[0-9]+)$'
         if [[ ${{ inputs.release-notes-release }} =~ $semver ]]; then
           log_info "Custom release-notes version '${{ inputs.release-notes-release }}' requested"
@@ -113,25 +100,68 @@ runs:
           exit 1
         fi
 
-        # Download custom release-notes
-        log_info "Downloading platform-specific version '${{ inputs.release-notes-release }}' of release-notes...\n      https://github.com/kubernetes/release/releases/download/v${{ inputs.release-notes-release }}/${desired_rn_filename}"
-        $SUDO curl -sL https://github.com/kubernetes/release/releases/download/v${{ inputs.release-notes-release }}/${desired_rn_filename} -o ${rn_executable_name}
+        RELEASE_URL="https://github.com/kubernetes/release/releases/download/v${{ inputs.release-notes-release }}"
 
-        RN_CERT=https://github.com/kubernetes/release/releases/download/v${{ inputs.release-notes-release }}/${desired_rn_filename}.pem
-        RN_SIG=https://github.com/kubernetes/release/releases/download/v${{ inputs.release-notes-release }}/${desired_rn_filename}.sig
+        # The binary and its signatures are staged in a temporary directory. The
+        # AMPEL policy is evaluated by collecting from that directory, so it must
+        # hold the artifact next to its signature files and nothing else.
+        verify_dir="$(mktemp -d)"
 
-        log_info "Using cosign to verify signature of desired release-notes version"
-        cosign verify-blob --certificate $RN_CERT --signature $RN_SIG \
-          --certificate-identity "https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/v${{ inputs.release-notes-release }}" \
-          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${rn_executable_name}
-        retVal=$?
-        if [[ $retVal -eq 0 ]]; then
-          $SUDO chmod +x ${rn_executable_name}
-          log_info "Installation complete!"
+        log_info "Downloading platform-specific version '${{ inputs.release-notes-release }}' of release-notes...\n      ${RELEASE_URL}/${desired_rn_filename}"
+        curl -sfL "${RELEASE_URL}/${desired_rn_filename}" -o "${verify_dir}/${desired_rn_filename}"
+
+        # Releases are signed either with a detached certificate + signature pair
+        # or with a sigstore bundle. Try both: whichever the release published
+        # will land in the verification directory and the rest simply 404.
+        for ext in .sig .pem .sigstore.json; do
+          if curl -sfL "${RELEASE_URL}/${desired_rn_filename}${ext}" -o "${verify_dir}/${desired_rn_filename}${ext}"; then
+            log_info "Fetched signature file ${desired_rn_filename}${ext}"
+          else
+            rm -f "${verify_dir}/${desired_rn_filename}${ext}"
+          fi
+        done
+
+        {
+          echo "verify-dir=${verify_dir}"
+          echo "artifact=${verify_dir}/${desired_rn_filename}"
+          echo "executable=${rn_executable_name}"
+        } >> "$GITHUB_OUTPUT"
+
+    # Verifies the downloaded binary carries a sigstore signature from the
+    # kubernetes/release release workflow. The policy accepts both the legacy
+    # detached certificate + signature pair and the newer sigstore bundle.
+    - name: Verify release-notes signature
+      uses: carabiner-dev/actions/ampel/verify@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+      with:
+        subject: ${{ steps.download.outputs.artifact }}
+        collector: fs:${{ steps.download.outputs.verify-dir }}
+        policy: git+https://github.com/carabiner-dev/policies#sigstore/sigstore-dual-signatures.json
+        signer: sigstore::https://token.actions.githubusercontent.com::https://github.com/kubernetes/release/.github/workflows/release.yml@refs/tags/v${{ inputs.release-notes-release }}
+        attest: "false"
+
+    - shell: bash
+      run: |
+        shopt -s expand_aliases
+        if [ -z "$NO_COLOR" ]; then
+          alias log_info="echo -e \"\033[1;32mINFO\033[0m:\""
         else
-          log_error "Unable to validate the release-notes binary: '${{ inputs.release-notes-release }}'"
-          exit 1
+          alias log_info="echo \"INFO:\""
         fi
+        set -e
+
+        SUDO=
+        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
+          SUDO=sudo
+        fi
+
+        $SUDO mkdir -p ${{ inputs.install-dir }}
+        $SUDO install -m 0755 "${ARTIFACT}" "${{ inputs.install-dir }}/${EXECUTABLE}"
+        rm -rf "${VERIFY_DIR}"
+        log_info "Installation complete!"
+      env:
+        ARTIFACT: ${{ steps.download.outputs.artifact }}
+        VERIFY_DIR: ${{ steps.download.outputs.verify-dir }}
+        EXECUTABLE: ${{ steps.download.outputs.executable }}
 
     - run: echo "${{ inputs.install-dir }}" >> $GITHUB_PATH
       shell: bash

--- a/setup-tejolote/action.yml
+++ b/setup-tejolote/action.yml
@@ -35,13 +35,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-      with:
-        install-dir: ${{ inputs.install-dir }}
-        use-sudo: ${{ inputs.use-sudo }}
-    - shell: bash
+    - id: download
+      shell: bash
       run: |
-        #!/bin/bash
+        #!/usr/bin/env bash
         # tejolote install script
         shopt -s expand_aliases
         if [ -z "$NO_COLOR" ]; then
@@ -53,73 +50,34 @@ runs:
         fi
         set -e
 
-        mkdir -p ${{ inputs.install-dir }}
-
-        trap "popd >/dev/null" EXIT
-
-        pushd ${{ inputs.install-dir }} > /dev/null
         tejolote_executable_name='tejolote'
         case ${{ runner.os }} in
           Linux)
             case ${{ runner.arch }} in
-              X64)
-                desired_tejolote_filename='tejolote-amd64-linux'
-                ;;
-
-              ARM)
-                desired_tejolote_filename='tejolote-arm-linux'
-                ;;
-
-              ARM64)
-                desired_tejolote_filename='tejolote-arm64-linux'
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_tejolote_filename='tejolote-amd64-linux' ;;
+              ARM)   desired_tejolote_filename='tejolote-arm-linux' ;;
+              ARM64) desired_tejolote_filename='tejolote-arm64-linux' ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
           macOS)
             case ${{ runner.arch }} in
-              X64)
-                desired_tejolote_filename='tejolote-amd64-darwin'
-                ;;
-
-              ARM64)
-                desired_tejolote_filename='tejolote-arm64-darwin'
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_tejolote_filename='tejolote-amd64-darwin' ;;
+              ARM64) desired_tejolote_filename='tejolote-arm64-darwin' ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
           Windows)
             case ${{ runner.arch }} in
               X64)
                 desired_tejolote_filename='tejolote-amd64-windows.exe'
                 tejolote_executable_name=tejolote.exe
                 ;;
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-          *)
-            log_error "unsupported architecture $arch"
-            exit 1
-            ;;
+          *) log_error "unsupported architecture $arch"; exit 1 ;;
         esac
-
-        SUDO=
-        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
-          SUDO=sudo
-        fi
 
         semver='^([0-9]+\.){0,2}(\*|[0-9]+)$'
         if [[ ${{ inputs.tejolote-release }} =~ $semver ]]; then
@@ -129,34 +87,62 @@ runs:
           exit 1
         fi
 
-        # Download custom tejolote
-        log_info "Downloading platform-specific version '${{ inputs.tejolote-release }}' of tejolote...\n      https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename}"
-        $SUDO curl -sL https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename} -o ${tejolote_executable_name}
+        RELEASE_URL="https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}"
 
-        TEJOLOTE_BUNDLE_URL=https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename}.sigstore.json
-        TEJOLOTE_CERT=https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename}.pem
-        TEJOLOTE_SIG=https://github.com/kubernetes-sigs/tejolote/releases/download/v${{ inputs.tejolote-release }}/${desired_tejolote_filename}.sig
+        # Stage the binary and its signatures in a dedicated directory (relative
+        # to the workspace, which keeps the path portable across runners) so the
+        # AMPEL policy can be evaluated by collecting from it.
+        verify_dir="ampel-verify-tejolote"
+        rm -rf "${verify_dir}"
+        mkdir -p "${verify_dir}"
 
-        log_info "Using cosign to verify signature of desired tejolote version"
-        if $SUDO curl -sfL "$TEJOLOTE_BUNDLE_URL" -o ${desired_tejolote_filename}.sigstore.json 2>/dev/null; then
-          log_info "Using bundle verification"
-          cosign verify-blob --bundle ${desired_tejolote_filename}.sigstore.json \
-            --certificate-identity "https://github.com/kubernetes-sigs/tejolote/.github/workflows/release.yml@refs/tags/v${{ inputs.tejolote-release }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${tejolote_executable_name}
-        else
-          log_info "Using legacy certificate/signature verification"
-          cosign verify-blob --certificate $TEJOLOTE_CERT --signature $TEJOLOTE_SIG \
-            --certificate-identity "https://github.com/kubernetes-sigs/tejolote/.github/workflows/release.yml@refs/tags/v${{ inputs.tejolote-release }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${tejolote_executable_name}
+        log_info "Downloading platform-specific version '${{ inputs.tejolote-release }}' of tejolote...\n      ${RELEASE_URL}/${desired_tejolote_filename}"
+        curl -sfL "${RELEASE_URL}/${desired_tejolote_filename}" -o "${verify_dir}/${desired_tejolote_filename}"
+
+        # Releases are signed either with a detached certificate + signature
+        # pair or with a sigstore bundle. Fetch whichever the release published;
+        # the others simply 404 and are removed.
+        for ext in .sig .pem .sigstore.json; do
+          if curl -sfL "${RELEASE_URL}/${desired_tejolote_filename}${ext}" -o "${verify_dir}/${desired_tejolote_filename}${ext}"; then
+            log_info "Fetched signature file ${desired_tejolote_filename}${ext}"
+          else
+            rm -f "${verify_dir}/${desired_tejolote_filename}${ext}"
+          fi
+        done
+
+        {
+          echo "verify-dir=${verify_dir}"
+          echo "artifact=${verify_dir}/${desired_tejolote_filename}"
+          echo "executable=${tejolote_executable_name}"
+        } >> "$GITHUB_OUTPUT"
+
+    # Verifies the downloaded binary carries a sigstore signature from the
+    # tejolote release workflow. The policy accepts both the legacy detached
+    # certificate + signature pair and the newer sigstore bundle.
+    - name: Verify tejolote signature
+      uses: carabiner-dev/actions/ampel/verify@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+      with:
+        subject: ${{ steps.download.outputs.artifact }}
+        collector: fs:${{ steps.download.outputs.verify-dir }}
+        policy: git+https://github.com/carabiner-dev/policies#sigstore/sigstore-dual-signatures.json
+        signer: sigstore::https://token.actions.githubusercontent.com::https://github.com/kubernetes-sigs/tejolote/.github/workflows/release.yml@refs/tags/v${{ inputs.tejolote-release }}
+        attest: "false"
+
+    - name: Install tejolote
+      shell: bash
+      run: |
+        set -e
+        SUDO=
+        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
+          SUDO=sudo
         fi
-        retVal=$?
-        if [[ $retVal -eq 0 ]]; then
-          $SUDO chmod +x ${tejolote_executable_name}
-          log_info "Installation complete!"
-        else
-          log_error "Unable to validate tejolote version: '${{ inputs.tejolote-release }}'"
-          exit 1
-        fi
+        $SUDO mkdir -p "${{ inputs.install-dir }}"
+        $SUDO install -m 0755 "${ARTIFACT}" "${{ inputs.install-dir }}/${EXECUTABLE}"
+        rm -rf "${VERIFY_DIR}"
+      env:
+        ARTIFACT: ${{ steps.download.outputs.artifact }}
+        EXECUTABLE: ${{ steps.download.outputs.executable }}
+        VERIFY_DIR: ${{ steps.download.outputs.verify-dir }}
 
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       run: echo "${{ inputs.install-dir }}" >> $GITHUB_PATH

--- a/setup-zeitgeist/action.yml
+++ b/setup-zeitgeist/action.yml
@@ -39,11 +39,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-      with:
-        install-dir: ${{ inputs.install-dir }}
-        use-sudo: ${{ inputs.use-sudo }}
-    - shell: bash
+    - id: download
+      shell: bash
       run: |
         #!/usr/bin/env bash
         # zeitgeist install script
@@ -57,86 +54,54 @@ runs:
         fi
         set -e
 
-        mkdir -p ${{ inputs.install-dir }}
-
-        export ZEITGIEST_REMOTE=
+        # The remote build checks dependencies from upstream repositories and
+        # registries; its release artifacts carry a "-remote" suffix.
+        ZEITGIEST_REMOTE=
         if [[ ${{ inputs.remote-version }} == "true" ]]; then
-          export ZEITGIEST_REMOTE=-remote
+          ZEITGIEST_REMOTE=-remote
         fi
 
+        # Fast path: install the development build straight from source. This
+        # path installs via a symlink and therefore skips the signature
+        # verification and install steps that follow.
         if [[ ${{ inputs.zeitgeist-release }} == "main" && ${{ inputs.remote-version }} == "false" ]]; then
           log_info "installing zeitgeist via 'go install' from its main version"
+          mkdir -p "${{ inputs.install-dir }}"
           GOBIN=$(go env GOPATH)/bin
           go install sigs.k8s.io/zeitgeist@master
-          ln -s $GOBIN/zeitgeist ${{ inputs.install-dir}}/zeitgeist
+          ln -s "$GOBIN/zeitgeist" "${{ inputs.install-dir }}/zeitgeist"
+          echo "mode=goinstall" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        trap "popd >/dev/null" EXIT
-
-        pushd ${{ inputs.install-dir }} > /dev/null
         zeitgeist_executable_name='zeitgeist'
         case ${{ runner.os }} in
           Linux)
             case ${{ runner.arch }} in
-              X64)
-                desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-amd64-linux"
-                ;;
-
-              ARM)
-                desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-arm-linux"
-                ;;
-
-              ARM64)
-                desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-arm64-linux"
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-amd64-linux" ;;
+              ARM)   desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-arm-linux" ;;
+              ARM64) desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-arm64-linux" ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
           macOS)
             case ${{ runner.arch }} in
-              X64)
-                desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-amd64-darwin"
-                ;;
-
-              ARM64)
-                desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-arm64-darwin"
-                ;;
-
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              X64)   desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-amd64-darwin" ;;
+              ARM64) desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-arm64-darwin" ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-
           Windows)
             case ${{ runner.arch }} in
               X64)
                 desired_zeitgeist_filename="zeitgeist${ZEITGIEST_REMOTE}-amd64-windows.exe"
                 zeitgeist_executable_name=zeitgeist.exe
                 ;;
-              *)
-                log_error "unsupported architecture $arch"
-                exit 1
-                ;;
+              *) log_error "unsupported architecture $arch"; exit 1 ;;
             esac
             ;;
-          *)
-            log_error "unsupported architecture $arch"
-            exit 1
-            ;;
+          *) log_error "unsupported architecture $arch"; exit 1 ;;
         esac
-
-        SUDO=
-        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
-          SUDO=sudo
-        fi
 
         semver='^([0-9]+\.){0,2}(\*|[0-9]+)$'
         if [[ ${{ inputs.zeitgeist-release }} =~ $semver ]]; then
@@ -146,25 +111,66 @@ runs:
           exit 1
         fi
 
-        # Download custom zeitgeist
-        log_info "Downloading platform-specific version '${{ inputs.zeitgeist-release }}' of zeitgeist...\n      https://github.com/kubernetes-sigs/zeitgeist/releases/download/v${{ inputs.zeitgeist-release }}/${desired_zeitgeist_filename}"
-        $SUDO curl -sL https://github.com/kubernetes-sigs/zeitgeist/releases/download/v${{ inputs.zeitgeist-release }}/${desired_zeitgeist_filename} -o ${zeitgeist_executable_name}
+        RELEASE_URL="https://github.com/kubernetes-sigs/zeitgeist/releases/download/v${{ inputs.zeitgeist-release }}"
 
-        ZEITGEIST_CERT=https://github.com/kubernetes-sigs/zeitgeist/releases/download/v${{ inputs.zeitgeist-release }}/${desired_zeitgeist_filename}.pem
-        ZEITGEIST_SIG=https://github.com/kubernetes-sigs/zeitgeist/releases/download/v${{ inputs.zeitgeist-release }}/${desired_zeitgeist_filename}.sig
+        # Stage the binary and its signatures in a dedicated directory (relative
+        # to the workspace, which keeps the path portable across runners) so the
+        # AMPEL policy can be evaluated by collecting from it.
+        verify_dir="ampel-verify-zeitgeist"
+        rm -rf "${verify_dir}"
+        mkdir -p "${verify_dir}"
 
-        log_info "Using cosign to verify signature of desired zeitgeist version"
-        cosign verify-blob --certificate $ZEITGEIST_CERT --signature $ZEITGEIST_SIG \
-          --certificate-identity "https://github.com/kubernetes-sigs/zeitgeist/.github/workflows/release.yml@refs/tags/v${{ inputs.zeitgeist-release }}" \
-          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ${zeitgeist_executable_name}
-        retVal=$?
-        if [[ $retVal -eq 0 ]]; then
-          $SUDO chmod +x ${zeitgeist_executable_name}
-          log_info "Installation complete!"
-        else
-          log_error "Unable to validate zeitgeist version: '${{ inputs.zeitgeist-release }}'"
-          exit 1
+        log_info "Downloading platform-specific version '${{ inputs.zeitgeist-release }}' of zeitgeist...\n      ${RELEASE_URL}/${desired_zeitgeist_filename}"
+        curl -sfL "${RELEASE_URL}/${desired_zeitgeist_filename}" -o "${verify_dir}/${desired_zeitgeist_filename}"
+
+        # Releases are signed either with a detached certificate + signature
+        # pair or with a sigstore bundle. Fetch whichever the release published;
+        # the others simply 404 and are removed.
+        for ext in .sig .pem .sigstore.json; do
+          if curl -sfL "${RELEASE_URL}/${desired_zeitgeist_filename}${ext}" -o "${verify_dir}/${desired_zeitgeist_filename}${ext}"; then
+            log_info "Fetched signature file ${desired_zeitgeist_filename}${ext}"
+          else
+            rm -f "${verify_dir}/${desired_zeitgeist_filename}${ext}"
+          fi
+        done
+
+        {
+          echo "verify-dir=${verify_dir}"
+          echo "artifact=${verify_dir}/${desired_zeitgeist_filename}"
+          echo "executable=${zeitgeist_executable_name}"
+          echo "mode=download"
+        } >> "$GITHUB_OUTPUT"
+
+    # Verifies the downloaded binary carries a sigstore signature from the
+    # zeitgeist release workflow. The policy accepts both the legacy detached
+    # certificate + signature pair and the newer sigstore bundle. Skipped for
+    # the go-install fast path, which does not download a release artifact.
+    - name: Verify zeitgeist signature
+      if: ${{ steps.download.outputs.mode == 'download' }}
+      uses: carabiner-dev/actions/ampel/verify@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+      with:
+        subject: ${{ steps.download.outputs.artifact }}
+        collector: fs:${{ steps.download.outputs.verify-dir }}
+        policy: git+https://github.com/carabiner-dev/policies#sigstore/sigstore-dual-signatures.json
+        signer: sigstore::https://token.actions.githubusercontent.com::https://github.com/kubernetes-sigs/zeitgeist/.github/workflows/release.yml@refs/tags/v${{ inputs.zeitgeist-release }}
+        attest: "false"
+
+    - name: Install zeitgeist
+      if: ${{ steps.download.outputs.mode == 'download' }}
+      shell: bash
+      run: |
+        set -e
+        SUDO=
+        if "${{ inputs.use-sudo }}" == "true" && command -v sudo >/dev/null; then
+          SUDO=sudo
         fi
+        $SUDO mkdir -p "${{ inputs.install-dir }}"
+        $SUDO install -m 0755 "${ARTIFACT}" "${{ inputs.install-dir }}/${EXECUTABLE}"
+        rm -rf "${VERIFY_DIR}"
+      env:
+        ARTIFACT: ${{ steps.download.outputs.artifact }}
+        EXECUTABLE: ${{ steps.download.outputs.executable }}
+        VERIFY_DIR: ${{ steps.download.outputs.verify-dir }}
 
     - if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       run: echo "${{ inputs.install-dir }}" >> $GITHUB_PATH


### PR DESCRIPTION
Since we switched to signing to a sigstore bundles, the current binary verification is failing as some releases have detatched signatures and some have bundles.

This PR swaps the cosign verification in the installer with an AMPEL policy that verifies the binaries regardless of the signature type they have.