### PR TITLE
Update setup-release-notes default version to v0.21.1

### DIFF
--- a/setup-release-notes/action.yaml
+++ b/setup-release-notes/action.yaml
@@ -23,7 +23,7 @@ inputs:
   release-notes-release:
     description: 'kubernetes/release version to be installed'
     required: false
-    default: '0.21.0'
+    default: '0.21.1'
   install-dir:
     description: 'Where to install the release-notes binary'
     required: false


### PR DESCRIPTION
Bumps the default tool version installed by the setup-release-notes action from v0.21.0 to v0.21.1.

Latest release: https://github.com/kubernetes/release/releases/tag/v0.21.1

```release-note
Update the default tool version installed by the setup-release-notes action to v0.21.1
```
