### PR TITLE
Update setup-zeitgeist default version to v0.8.0

### DIFF
--- a/setup-zeitgeist/action.yml
+++ b/setup-zeitgeist/action.yml
@@ -23,7 +23,7 @@ inputs:
   zeitgeist-release:
     description: 'zeitgeist release version to be installed'
     required: false
-    default: '0.7.0'
+    default: '0.8.0'
   remote-version:
     description: 'install zeitgeist that can check depencies from upstream repositories/registries. If false will install the local version only that only check local dependencies'
     required: false


### PR DESCRIPTION
Bumps the default tool version installed by the setup-zeitgeist action from v0.7.0 to v0.8.0.

Latest release: https://github.com/kubernetes-sigs/zeitgeist/releases/tag/v0.8.0

```release-note
Update the default tool version installed by the setup-zeitgeist action to v0.8.0
```
